### PR TITLE
Feature/add field

### DIFF
--- a/evalcat/result_list.py
+++ b/evalcat/result_list.py
@@ -28,6 +28,8 @@ class ResultList:
         ```
     fields : list of Field
         Contains the fields to be evaluated. List items should be instances of Field subclasses.
+    k : int
+        Depth of search results for metrics to be computed.
 
     Attributes
     ----------
@@ -72,6 +74,18 @@ class ResultList:
             raise TypeError("`field_name` must be a string.")
 
     def add_fields(self, fields, k=10, replace=False):
+        """Adds new fields to the ResultList and computes metrics.
+
+        Parameters
+        ----------
+        fields : list of Field, or Field
+            Contains the fields to be evaluated. List items should be instances of Field subclasses.
+        k : int
+            Depth of search results for metrics to be computed.
+        replace : bool, default=False
+            If false, raises ValueError if there  is already a field with the same name as the new field.
+            Else it will replace the old field.
+        """
         if isinstance(fields, Field):
             fields = [fields]
         for f in fields:

--- a/evalcat/result_list.py
+++ b/evalcat/result_list.py
@@ -53,12 +53,10 @@ class ResultList:
             self.base_result = results
         else:
             self.base_result = BaseResult(results, **kwargs)
-        self.fields = fields
+        self.fields = fields if fields else []
         self.summary = self._compute_summary(k)
 
     def _compute_summary(self, k=10):
-        if not self.fields:
-            return
         summary = {}
         for field in self.fields:
             summary[field.name] = field.compute_metrics(self.base_result, k)
@@ -72,6 +70,15 @@ class ResultList:
                 return self.summary[field_name]
         else:
             raise TypeError("`field_name` must be a string.")
+
+    def add_field(self, fields, k=10, replace=False):
+        if isinstance(fields, Field):
+            fields = [fields]
+        for f in fields:
+            if f.name in self.summary and not replace:
+                raise ValueError(f'Field {f} already exists. Pass `replace=True` to override.')
+            self.fields.append(f)
+            self.summary[f.name] = f.compute_metrics(self.base_result, k)
 
     def get_query_metric_df(self, field_name, system):
         """Returns a DataFrame comparing queries against metrics for a single system.

--- a/evalcat/result_list.py
+++ b/evalcat/result_list.py
@@ -71,7 +71,7 @@ class ResultList:
         else:
             raise TypeError("`field_name` must be a string.")
 
-    def add_field(self, fields, k=10, replace=False):
+    def add_fields(self, fields, k=10, replace=False):
         if isinstance(fields, Field):
             fields = [fields]
         for f in fields:

--- a/evalcat/tests/test_result_list.py
+++ b/evalcat/tests/test_result_list.py
@@ -91,8 +91,8 @@ class TestResultList(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.result_list._get_field_from_summary(12)
 
-    def test_add_field(self):
-        self.result_list.add_field(MockField2('mock2'))
+    def test_add_fields(self):
+        self.result_list.add_fields(MockField2('mock2'))
         self.assertIn('mock2', self.result_list.summary)
         self.assertIn('metric_sum', self.result_list.summary['mock2'].columns)
         # Check mock is unaffected.
@@ -101,10 +101,10 @@ class TestResultList(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             # Did not pass `replace=True` when adding a valid field.
-            self.result_list.add_field(MockField())
+            self.result_list.add_fields(MockField())
 
         # Replace original mock field with mock2.
-        self.result_list.add_field(MockField2('mock'), replace=True)
+        self.result_list.add_fields(MockField2('mock'), replace=True)
         self.assertIn('mock', self.result_list.summary)
         self.assertIn('metric_sum', self.result_list.summary['mock'].columns)
         # Should not have metric_product.


### PR DESCRIPTION
#13 

Added function `add_fields` to add one or more `Field` objects after creation of `ResultList`. Allows replacing an already existing field when `replace=True` is passed. Also added unittest.

Example
```
res_list = ResultList(search_results)  # Fields are optional at creation.
res_list.add_fields([Field1(), Field2()])  # Fields added and metrics computed here.
```